### PR TITLE
fix issue #30

### DIFF
--- a/src/main/java/org/imsglobal/pox/IMSPOXRequest.java
+++ b/src/main/java/org/imsglobal/pox/IMSPOXRequest.java
@@ -513,6 +513,7 @@ public class IMSPOXRequest {
 			"	<imsx_POXHeader>"+
 			"		<imsx_POXRequestHeaderInfo>"+
 			"			<imsx_version>V1.0</imsx_version>"+
+			"			<imsx_messageIdentifier>%s</imsx_messageIdentifier>" +
 			"		</imsx_POXRequestHeaderInfo>"+
 			"	</imsx_POXHeader>"+
 			"	<imsx_POXBody>"+
@@ -553,14 +554,20 @@ public class IMSPOXRequest {
 					response.getStatusLine().getReasonPhrase());
 		}
 	}
-
-	public static HttpPost buildReplaceResult(String url, String key, String secret, String sourcedid, String score, String resultData, Boolean isUrl) throws IOException, OAuthException, GeneralSecurityException {
+	
+	public static HttpPost buildReplaceResult(String url, String key, String secret, String sourcedid, String score, String resultData, Boolean isUrl, String messageId) throws IOException, OAuthException, GeneralSecurityException {
 		String dataXml = "";
 		if (resultData != null) {
 			String format = isUrl ? resultDataUrl : resultDataText;
 			dataXml = String.format(format, StringEscapeUtils.escapeXml(resultData));
 		}
-		String xml = String.format(replaceResultMessage, StringEscapeUtils.escapeXml(sourcedid),
+		
+		String msgid = messageId;
+		if (messageId == null) {
+			msgid = String.valueOf(new Date().getTime());
+		}
+		
+		String xml = String.format(replaceResultMessage, StringEscapeUtils.escapeXml(msgid), StringEscapeUtils.escapeXml(sourcedid),
 				StringEscapeUtils.escapeXml(score), dataXml);
 
 		HttpParameters parameters = new HttpParameters();
@@ -574,6 +581,10 @@ public class IMSPOXRequest {
 		signer.setAdditionalParameters(parameters);
 		signer.sign(request);
 		return request;
+	}
+
+	public static HttpPost buildReplaceResult(String url, String key, String secret, String sourcedid, String score, String resultData, Boolean isUrl) throws IOException, OAuthException, GeneralSecurityException {
+		return buildReplaceResult(url, key, secret, sourcedid, score, resultData, isUrl, null);
 	}
 
 	/*

--- a/src/test/java/org/imsglobal/lti/pox/IMSPOXRequestTest.java
+++ b/src/test/java/org/imsglobal/lti/pox/IMSPOXRequestTest.java
@@ -28,9 +28,10 @@ public class IMSPOXRequestTest {
     @Test
     public void test(){
 
-        String inputTestData = String.format(IMSPOXRequest.replaceResultMessage, "3124567", "A", "");
+        String inputTestData = String.format(IMSPOXRequest.replaceResultMessage, "123", "3124567", "A", "");
         IMSPOXRequest pox = new IMSPOXRequest(inputTestData);
         Assert.assertEquals("V1.0", pox.getHeaderVersion());
+		Assert.assertEquals("123", pox.getHeaderMessageIdentifier());
         Assert.assertEquals("replaceResultRequest", pox.getOperation());
         Map<String,String> bodyMap = pox.getBodyMap();
         String guid = bodyMap.get("/resultRecord/sourcedGUID/sourcedId");


### PR DESCRIPTION
hi, please take a loot a fix for issue #30 . The summary of changes is following: 
1. add message id param for replaceResultMessage template.
2. initialize  message id by current time in millisecond if no explicit value passed from user call.
3. add API for explicit message id definition.