### PR TITLE
update replaceResult with messageIdentifier - fix for issue#27

### DIFF
--- a/src/main/java/org/imsglobal/pox/IMSPOXRequest.java
+++ b/src/main/java/org/imsglobal/pox/IMSPOXRequest.java
@@ -33,6 +33,7 @@ import oauth.signpost.http.HttpParameters;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpPost;
@@ -513,6 +514,7 @@ public class IMSPOXRequest {
 			"	<imsx_POXHeader>"+
 			"		<imsx_POXRequestHeaderInfo>"+
 			"			<imsx_version>V1.0</imsx_version>"+
+			"			<imsx_messageIdentifier>%s</imsx_messageIdentifier>"+
 			"		</imsx_POXRequestHeaderInfo>"+
 			"	</imsx_POXHeader>"+
 			"	<imsx_POXBody>"+
@@ -523,6 +525,7 @@ public class IMSPOXRequest {
 			"				</sourcedGUID>"+
 			"				<result>"+
 			"					<resultScore>"+
+			"						<language>en</language>"+
 			"						<textString>%s</textString>"+
 			"					</resultScore>"+
 			"					%s"+
@@ -555,13 +558,24 @@ public class IMSPOXRequest {
 	}
 
 	public static HttpPost buildReplaceResult(String url, String key, String secret, String sourcedid, String score, String resultData, Boolean isUrl) throws IOException, OAuthException, GeneralSecurityException {
+		return buildReplaceResult(url, key, secret, sourcedid, score, resultData, isUrl, null);
+	}
+
+	public static HttpPost buildReplaceResult(String url, String key, String secret, String sourcedid,
+		String score, String resultData, Boolean isUrl, String messageId) throws IOException, OAuthException, GeneralSecurityException
+	{
 		String dataXml = "";
 		if (resultData != null) {
 			String format = isUrl ? resultDataUrl : resultDataText;
 			dataXml = String.format(format, StringEscapeUtils.escapeXml(resultData));
 		}
-		String xml = String.format(replaceResultMessage, StringEscapeUtils.escapeXml(sourcedid),
-				StringEscapeUtils.escapeXml(score), dataXml);
+
+		String messageIdentifier = StringUtils.isBlank(messageId) ? String.valueOf(new Date().getTime()) : messageId;
+		String xml = String.format(replaceResultMessage,
+			StringEscapeUtils.escapeXml(messageIdentifier),
+			StringEscapeUtils.escapeXml(sourcedid),
+			StringEscapeUtils.escapeXml(score),
+			dataXml);
 
 		HttpParameters parameters = new HttpParameters();
 		String hash = getBodyHash(xml);

--- a/src/test/java/org/imsglobal/lti/pox/IMSPOXRequestTest.java
+++ b/src/test/java/org/imsglobal/lti/pox/IMSPOXRequestTest.java
@@ -1,56 +1,51 @@
 package org.imsglobal.lti.pox;
 
-import net.oauth.OAuthMessage;
-
-import org.apache.http.Header;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.params.HttpParams;
 import org.imsglobal.pox.IMSPOXRequest;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.*;
+import java.util.Date;
+import java.util.Map;
 
 /**
  * Created by pgray on 7/5/14.
  */
 public class IMSPOXRequestTest {
 
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
     @Test
-    public void test(){
+    public void test() {
 
-        String inputTestData = String.format(IMSPOXRequest.replaceResultMessage, "3124567", "A", "");
+        String messageId = String.valueOf(new Date().getTime());
+        String inputTestData = String.format(IMSPOXRequest.replaceResultMessage, messageId, "3124567", "A", "");
         IMSPOXRequest pox = new IMSPOXRequest(inputTestData);
         Assert.assertEquals("V1.0", pox.getHeaderVersion());
         Assert.assertEquals("replaceResultRequest", pox.getOperation());
-        Map<String,String> bodyMap = pox.getBodyMap();
+        Assert.assertEquals("should match messageId", messageId, pox.getHeaderMessageIdentifier());
+
+        Map<String, String> bodyMap = pox.getBodyMap();
         String guid = bodyMap.get("/resultRecord/sourcedGUID/sourcedId");
         Assert.assertEquals("3124567", guid);
         String grade = bodyMap.get("/resultRecord/result/resultScore/textString");
         Assert.assertEquals("A", grade);
-
+        String resultScoreLang = bodyMap.get("/resultRecord/result/resultScore/language");
+        Assert.assertEquals("should have resultScore lang set to en", "en", resultScoreLang);
     }
 
     @Test
     public void testBuildReplaceResult() throws Exception {
-		HttpPost post = IMSPOXRequest.buildReplaceResult("http://example.com", "key", "secret", "sourcedid", "0.95", "A", false);
-		String header = post.getHeaders("Authorization")[0].getValue();
-		InputStream input = post.getEntity().getContent();
-		Reader reader = new InputStreamReader(input);
-		String body = IMSPOXRequest.readPostBody(reader);
+        HttpPost post = IMSPOXRequest.buildReplaceResult("http://example.com", "key", "secret", "sourcedid", "0.95", "A", false);
+        String header = post.getHeaders("Authorization")[0].getValue();
+        InputStream input = post.getEntity().getContent();
+        Reader reader = new InputStreamReader(input);
+        String body = IMSPOXRequest.readPostBody(reader);
 
-		IMSPOXRequest pox = new IMSPOXRequest(body);
-		pox.setAuthHeader(header);
-		pox.validatePostBody();
-		Assert.assertNull(pox.errorMessage);
+        IMSPOXRequest pox = new IMSPOXRequest(body);
+        pox.setAuthHeader(header);
+        pox.validatePostBody();
+        Assert.assertNull(pox.errorMessage);
     }
 }


### PR DESCRIPTION
- add imsx_messageIdentifier as part of replaceResult
- add language en along with resultScore textString
