### PR TITLE
Bump up version of apache httpclient.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.0.1</version>
+            <version>4.5.5</version>
         </dependency>
         <dependency>
             <groupId>oauth.signpost</groupId>


### PR DESCRIPTION
httpclient version 4.0.1 has been deprecated and affected by all the vulnerabilities which are listed in https://www.cvedetails.com/product/20943/Apache-Httpclient.html?vendor_id=45